### PR TITLE
Created dedicated flake overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,14 @@
         "aarch64-linux"
       ];
 
-      flake.nixosModules = import ./nix/modules;
+      flake =
+        { config, ... }:
+        {
+          nixosModules = import ./nix/modules;
+          overlays.default = _final: _prev: {
+            nix-store-veritysetup-generator = config.packages.nix-store-veritysetup-generator;
+          };
+        };
 
       perSystem =
         {
@@ -43,15 +50,6 @@
           ...
         }:
         {
-
-          _module.args.pkgs = import inputs.nixpkgs {
-            inherit system;
-            overlays = [
-              (_final: _prev: {
-                nix-store-veritysetup-generator = config.packages.nix-store-veritysetup-generator;
-              })
-            ];
-          };
 
           packages = {
             nix-store-veritysetup-generator = pkgs.callPackage ./. { };


### PR DESCRIPTION
This removes the custom pkgs arguments in favor of a default flake overlay.

Doing so enables the follows mechanism for flakes consuming this one.

Some more info: Reinstantiating nixpkgs in consumable flakes seems to be unwise in general: https://zimbatm.com/notes/1000-instances-of-nixpkgs if I understand correctly what your goal is, the better way is to just use pkgs as provided by flake-parts and then create an overlay that exposes the new package.

I've created a quick and dirty test flake that seems to work this way:

```
{
	description = "flake to test overlay";

	inputs = {
		nixpkgs.url = "nixpkgs/nixos-unstable";
		unitgen = {
			url = "github:IncredibleLaser/nix-store-veritysetup-generator/no-import-nixpkgs";
			inputs.nixpkgs.follows = "nixpkgs";
		};
	};

	outputs = { nixpkgs, ... }:
	let
	  system = "x86_64-linux";
	  pkgs = nixpkgs.legacyPackages.${system};
	in

	{
		devShells.${system}.default = pkgs.mkShell {
			packages = [ pkgs.nix-store-veritysetup-generator ];
		};
	};
}
```

Running `nix develop .` on this flake gives a shell with nix-store-veritysetup-generator available.

If I've misunderstood what's being done here (currently learning about nix myself so can't say I'm authoritative), feel free to reject. I just saw the presentation from All Systems Go! regarding NixOS Platform Security and am very intrigued.

EDIT: Closing this because I think I misunderstood and configuring via _module.args works differently and as such, there's nothing to fix here. Also, the package is referenced in the tests.