### PR TITLE
rust: fix self-referencing symlink by targeting parent directory instead

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -135,7 +135,8 @@ fn generator_symlink(
     fs::create_dir_all(&dir).with_context(|| format!("Failed to create {dir}"))?;
 
     let symlink = format!("{dir}/{src_unit}");
-    std::os::unix::fs::symlink(src_unit, &symlink)
+    let link_target = format!("../{src_unit}");
+    std::os::unix::fs::symlink(link_target, &symlink)
         .with_context(|| format!("Failed to create symlink {symlink}"))?;
 
     Ok(())


### PR DESCRIPTION
Prior to this commit the symlink was placed at `{dir}/{src_unit}`, pointing to `{src_unit}`, thus referencing itself. Now it points to the parent directory instead, where the actual service file is located. I didn't further investigate to why this wasn't an issue prior to systemd v258, but this fixes the generator for the release.

I did not opt for a generic approach here because I couldn't see a need for it.